### PR TITLE
Update PV upload instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository hosts a complete Streamlit app that models a **Virtual Energy Co
 - Upload:
   - Households.xlsx (one sheet per household, 15-min kW → app converts to hourly kWh)
   - SmallShops.xlsx (one sheet per shop, 15-min kWh column `ActiveEnergy_Generale`)
-  - PV.json (per-kWp hourly kWh)
+  - PV.xlsx (hourly per-kWp kWh; download the preformatted template from the Upload & Fit page, covering 1 Jan 2018 00:30 to 31 Dec 2023 23:30)
   - zonal.csv (timestamp, `zonal_price (EUR_per_MWh)`), PUN_monthly.csv (timestamp, `PUN (EUR_per_kWh)`)
 - Click **Run fitting**. You’ll see parameter tables and diagnostics (histograms + QQ).
 


### PR DESCRIPTION
## Summary
- update the Page 1 upload instructions to reference the new PV.xlsx template
- clarify that the template provides hourly per-kWp data for 2018-01-01 00:30 through 2023-12-31 23:30 and is downloadable from the app

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68e233c136d4833280640ef0cdc25987