### PR TITLE
Remove PV JSON upload path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository hosts a complete Streamlit app that models a **Virtual Energy Co
 - Upload:
   - Households.xlsx (one sheet per household, 15-min kW → app converts to hourly kWh)
   - SmallShops.xlsx (one sheet per shop, 15-min kWh column `ActiveEnergy_Generale`)
-  - PV.json (per-kWp hourly kWh)
+  - PV.xlsx (hourly per-kWp kWh; download the preformatted template from the Upload & Fit page, covering 1 Jan 2018 00:30 to 31 Dec 2023 23:30)
   - zonal.csv (timestamp, `zonal_price (EUR_per_MWh)`), PUN_monthly.csv (timestamp, `PUN (EUR_per_kWh)`)
 - Click **Run fitting**. You’ll see parameter tables and diagnostics (histograms + QQ).
 

--- a/app.py
+++ b/app.py
@@ -19,7 +19,6 @@ from src.exporters import (
     build_calibration_workbook_pv, export_kpi_quantiles, export_kpi_samples,
     export_all_in_one_xlsx, export_hourly_facts, build_household_template,
     build_shop_template, build_pv_excel_template, build_zonal_price_template,
-    build_shop_template, build_pv_json_template, build_zonal_price_template,
     build_pun_monthly_template,
 )
 
@@ -80,15 +79,6 @@ Upload the **Households**, **Small Shops**, **PV per-kWp Excel**, and **Prices**
             help="Hourly timestamps (Europe/Rome) from 1 Jan 2018 00:30 to 31 Dec 2023 23:30.",
         )
         pv_file = st.file_uploader("PV.xlsx", type=["xlsx"])
-    with st.expander("Upload — Prosumer PV (JSON: per-kWp hourly kWh)", expanded=True):
-        st.download_button(
-            "Download PV JSON template (hourly, 2018-2023)",
-            build_pv_json_template(),
-            file_name="pv_template.json",
-            mime="application/json",
-            help="Hourly timestamps (Europe/Rome) from 1 Jan 2018 18:10 to 31 Dec 2023 23:10.",
-        )
-        pv_file = st.file_uploader("PV.json", type=["json"])
         if pv_file:
             with spinner_block("Reading PV Excel..."):
                 S.pv_perkwp = read_pv_excel(pv_file)

--- a/src/exporters.py
+++ b/src/exporters.py
@@ -1,5 +1,4 @@
 import io
-import json
 import pandas as pd
 import numpy as np
 from typing import Dict
@@ -65,18 +64,6 @@ def build_pv_excel_template(
     with pd.ExcelWriter(out, engine="xlsxwriter") as xl:
         df.to_excel(xl, sheet_name="PV_per_kWp", index=False)
     return out.getvalue()
-def build_pv_json_template(
-    start="2018-01-01 18:10", end="2023-12-31 23:10"
-) -> bytes:
-    """Create a JSON template for PV per-kWp hourly data."""
-
-    rng = pd.date_range(start=start, end=end, freq="h", tz=TZ)
-    records = [
-        {"timestamp": ts.strftime("%Y-%m-%d %H:%M:%S%z"), "energy_kWh_per_kWp": None}
-        for ts in rng
-    ]
-    json_bytes = json.dumps({"records": records}, ensure_ascii=False, indent=2).encode("utf-8")
-    return json_bytes
 
 
 def build_zonal_price_template(year: int) -> bytes:


### PR DESCRIPTION
## Summary
- remove the PV JSON template import and uploader so only the Excel workflow is available
- clean up the exporters module to drop the unused JSON template helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e233c136d4833280640ef0cdc25987