### PR TITLE
Ignore zero and missing hours during fitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository hosts a complete Streamlit app that models a **Virtual Energy Co
 - Upload:
   - Households.xlsx (one sheet per household, 15-min kW → app converts to hourly kWh)
   - SmallShops.xlsx (one sheet per shop, 15-min kWh column `ActiveEnergy_Generale`)
-  - PV.json (per-kWp hourly kWh)
+  - PV.xlsx (hourly per-kWp kWh; download the preformatted template from the Upload & Fit page, covering 1 Jan 2018 00:30 to 31 Dec 2023 23:30)
   - zonal.csv (timestamp, `zonal_price (EUR_per_MWh)`), PUN_monthly.csv (timestamp, `PUN (EUR_per_kWh)`)
 - Click **Run fitting**. You’ll see parameter tables and diagnostics (histograms + QQ).
 

--- a/app.py
+++ b/app.py
@@ -19,7 +19,6 @@ from src.exporters import (
     build_calibration_workbook_pv, export_kpi_quantiles, export_kpi_samples,
     export_all_in_one_xlsx, export_hourly_facts, build_household_template,
     build_shop_template, build_pv_excel_template, build_zonal_price_template,
-    build_shop_template, build_pv_json_template, build_zonal_price_template,
     build_pun_monthly_template,
 )
 
@@ -80,15 +79,6 @@ Upload the **Households**, **Small Shops**, **PV per-kWp Excel**, and **Prices**
             help="Hourly timestamps (Europe/Rome) from 1 Jan 2018 00:30 to 31 Dec 2023 23:30.",
         )
         pv_file = st.file_uploader("PV.xlsx", type=["xlsx"])
-    with st.expander("Upload — Prosumer PV (JSON: per-kWp hourly kWh)", expanded=True):
-        st.download_button(
-            "Download PV JSON template (hourly, 2018-2023)",
-            build_pv_json_template(),
-            file_name="pv_template.json",
-            mime="application/json",
-            help="Hourly timestamps (Europe/Rome) from 1 Jan 2018 18:10 to 31 Dec 2023 23:10.",
-        )
-        pv_file = st.file_uploader("PV.json", type=["json"])
         if pv_file:
             with spinner_block("Reading PV Excel..."):
                 S.pv_perkwp = read_pv_excel(pv_file)

--- a/src/exporters.py
+++ b/src/exporters.py
@@ -1,5 +1,4 @@
 import io
-import json
 import pandas as pd
 import numpy as np
 from typing import Dict
@@ -65,18 +64,6 @@ def build_pv_excel_template(
     with pd.ExcelWriter(out, engine="xlsxwriter") as xl:
         df.to_excel(xl, sheet_name="PV_per_kWp", index=False)
     return out.getvalue()
-def build_pv_json_template(
-    start="2018-01-01 18:10", end="2023-12-31 23:10"
-) -> bytes:
-    """Create a JSON template for PV per-kWp hourly data."""
-
-    rng = pd.date_range(start=start, end=end, freq="h", tz=TZ)
-    records = [
-        {"timestamp": ts.strftime("%Y-%m-%d %H:%M:%S%z"), "energy_kWh_per_kWp": None}
-        for ts in rng
-    ]
-    json_bytes = json.dumps({"records": records}, ensure_ascii=False, indent=2).encode("utf-8")
-    return json_bytes
 
 
 def build_zonal_price_template(year: int) -> bytes:

--- a/src/fitting.py
+++ b/src/fitting.py
@@ -22,6 +22,11 @@ def _fit_baseline_and_spreads(df: pd.DataFrame, id_col: str):
       sigma_resid: DataFrame index=cluster, columns=0..23 (σ_η(c,h))
       diag: dict with diagnostic frames
     """
+    df = df.copy()
+    df = df[df["kWh"].notna() & (df["kWh"] > 0)]
+    if df.empty:
+        raise ValueError(f"No positive hourly kWh values available for {id_col} after filtering.")
+
     df = _hourly_tables(df, id_col)
     # Daily totals per (id,date)
     daily = df.groupby([id_col, "date", "cluster"], as_index=False)["kWh"].sum().rename(columns={"kWh": "E_day"})

--- a/src/io_utils.py
+++ b/src/io_utils.py
@@ -4,6 +4,14 @@ from typing import IO
 
 from pandas.api import types as pdt
 
+
+def _to_positive_numeric(series: pd.Series) -> pd.Series:
+    """Coerce a series to numeric, keeping only strictly positive values."""
+
+    values = pd.to_numeric(series, errors="coerce")
+    values = values.where(values > 0, np.nan)
+    return values
+
 TZ = "Europe/Rome"
 
 def _ensure_ts_local(df: pd.DataFrame, col="timestamp") -> pd.DataFrame:
@@ -70,12 +78,19 @@ def read_households_excel(file: IO) -> pd.DataFrame:
         pcol = power_cols[0]
         df = df[["timestamp", pcol]].rename(columns={pcol: "power_kW_15min"})
         df = _ensure_ts_local(df, "timestamp")
-        df["kWh"] = df["power_kW_15min"].astype(float) * 0.25
+        df["kWh_15"] = _to_positive_numeric(df["power_kW_15min"]) * 0.25
         df["ts_h"] = df["timestamp"].dt.tz_convert("UTC").dt.floor("h").dt.tz_convert(TZ)
-        hourly = df.groupby("ts_h", as_index=False)["kWh"].sum().rename(columns={"ts_h": "timestamp"})
+        hourly = (
+            df.groupby("ts_h", as_index=False)["kWh_15"]
+            .sum(min_count=1)
+            .rename(columns={"ts_h": "timestamp", "kWh_15": "kWh"})
+        )
+        hourly = hourly.dropna(subset=["kWh"])
+        hourly = hourly[hourly["kWh"] > 0]
         hourly["household_id"] = sheet
         recs.append(hourly[["timestamp", "household_id", "kWh"]])
-    return pd.concat(recs, ignore_index=True).sort_values(["timestamp", "household_id"])
+    out = pd.concat(recs, ignore_index=True)
+    return out.sort_values(["timestamp", "household_id"]).reset_index(drop=True)
 
 def read_shops_excel(file: IO) -> pd.DataFrame:
     x = pd.ExcelFile(file)
@@ -91,11 +106,19 @@ def read_shops_excel(file: IO) -> pd.DataFrame:
         ecol = cands[0]
         df = df[["timestamp", ecol]].rename(columns={ecol: "kWh_15"})
         df = _ensure_ts_local(df, "timestamp")
+        df["kWh_15"] = _to_positive_numeric(df["kWh_15"])
         df["ts_h"] = df["timestamp"].dt.tz_convert("UTC").dt.floor("h").dt.tz_convert(TZ)
-        hourly = df.groupby("ts_h", as_index=False)["kWh_15"].sum().rename(columns={"ts_h": "timestamp", "kWh_15": "kWh"})
+        hourly = (
+            df.groupby("ts_h", as_index=False)["kWh_15"]
+            .sum(min_count=1)
+            .rename(columns={"ts_h": "timestamp", "kWh_15": "kWh"})
+        )
+        hourly = hourly.dropna(subset=["kWh"])
+        hourly = hourly[hourly["kWh"] > 0]
         hourly["shop_id"] = sheet
         recs.append(hourly[["timestamp", "shop_id", "kWh"]])
-    return pd.concat(recs, ignore_index=True).sort_values(["timestamp", "shop_id"])
+    out = pd.concat(recs, ignore_index=True)
+    return out.sort_values(["timestamp", "shop_id"]).reset_index(drop=True)
 
 def read_pv_excel(file: IO) -> pd.DataFrame:
     df = pd.read_excel(file)
@@ -106,7 +129,9 @@ def read_pv_excel(file: IO) -> pd.DataFrame:
         raise ValueError(f"[PV] Excel must contain columns: {', '.join(sorted(missing))}")
     df = df[["timestamp", "energy_kWh_per_kWp"]].rename(columns={"energy_kWh_per_kWp": "kWh_per_kWp"})
     df = _ensure_ts_local(df, "timestamp").sort_values("timestamp")
-    return df
+    df["kWh_per_kWp"] = _to_positive_numeric(df["kWh_per_kWp"])
+    df = df.dropna(subset=["kWh_per_kWp"])
+    return df.reset_index(drop=True)
 
 def read_zonal_csv(file: IO) -> pd.DataFrame:
     df = pd.read_csv(file)

--- a/src/pv_model.py
+++ b/src/pv_model.py
@@ -6,6 +6,9 @@ from .clustering import season_of
 
 def fit_pv_optionB_v3(pv_perkwp: pd.DataFrame) -> Tuple[Dict, Dict]:
     df = pv_perkwp.copy()
+    df = df[df["kWh_per_kWp"].notna() & (df["kWh_per_kWp"] > 0)]
+    if df.empty:
+        raise ValueError("No positive PV per-kWp hours available after filtering.")
     df["season"] = df["timestamp"].apply(season_of)
     df["hour"] = df["timestamp"].dt.hour
     # Envelope per season


### PR DESCRIPTION
## Summary
- filter the household and shop importers to drop non-positive quarter-hour readings before building hourly series
- discard zero or NaN PV per-kWp hours both at import time and inside the PV fitter
- guard the common fitting routine so calibration stops when no positive hours remain after filtering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e233c136d4833280640ef0cdc25987