### PR TITLE
Add prosumer median consumption template uploader

### DIFF
--- a/src/exporters.py
+++ b/src/exporters.py
@@ -121,6 +121,12 @@ def build_shop_template(year: int) -> bytes:
     return _build_profile_template_cached(int(year), "SHOP")
 
 
+def build_prosumer_template(year: int) -> bytes:
+    """Excel template for prosumer cluster medians (24×12 grid)."""
+
+    return _build_profile_template_cached(int(year), "PROSUMER")
+
+
 @lru_cache(maxsize=16)
 def _build_pv_excel_template_cached(year: int) -> bytes:
     start = pd.Timestamp(f"{int(year)}-01-01 00:00", tz=TZ)

--- a/src/io_utils.py
+++ b/src/io_utils.py
@@ -256,6 +256,12 @@ def read_shop_template(file: IO) -> pd.DataFrame:
 
     return _read_cluster_template(file, "SHOP")
 
+
+def read_prosumer_template(file: IO) -> pd.DataFrame:
+    """Read deterministic prosumer cluster medians (24×12)."""
+
+    return _read_cluster_template(file, "PROSUMER")
+
 def read_zonal_excel(file: IO) -> pd.DataFrame:
     buffer = _reset_file_like(file)
     df = _read_excel_with_flexible_header(buffer, {"timestamp"})

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -81,6 +81,7 @@ def run_deterministic(
     *,
     hours: pd.DatetimeIndex,
     pv_series: pd.Series,
+    prosumer_series: pd.Series,
     hh_series: pd.Series,
     shop_series: pd.Series,
     prosumers: pd.DataFrame,
@@ -114,6 +115,7 @@ def run_deterministic(
         raise ValueError("Hourly PUN has missing values after reindexing.")
 
     pv_series = _ensure_alignment(pv_series, hours, "PV template")
+    prosumer_series = _ensure_alignment(prosumer_series, hours, "Prosumer template")
     hh_series = _ensure_alignment(hh_series, hours, "Household template")
     shop_series = _ensure_alignment(shop_series, hours, "Shop template")
 
@@ -134,11 +136,12 @@ def run_deterministic(
     shop_province = shops.get("province", pd.Series("Province", index=shops.index)).astype(str).tolist()
 
     pv_vals = pv_series.to_numpy()
+    prosumer_vals = prosumer_series.to_numpy()
     hh_vals = hh_series.to_numpy()
     shop_vals = shop_series.to_numpy()
 
     pros_gen = (kwp[:, None] * pv_vals[None, :] * float(efficiency)) if nP else np.zeros((0, n_hours))
-    pros_load = (w_self[:, None] * hh_vals[None, :]) if nP else np.zeros((0, n_hours))
+    pros_load = (w_self[:, None] * prosumer_vals[None, :]) if nP else np.zeros((0, n_hours))
     pros_self = np.minimum(pros_gen, pros_load)
     pros_import = np.maximum(pros_load - pros_gen, 0.0)
     pros_surplus = np.maximum(pros_gen - pros_load, 0.0)

--- a/src/state.py
+++ b/src/state.py
@@ -12,6 +12,8 @@ class AppState:
     # Uploaded deterministic templates
     pv_df: Optional[pd.DataFrame] = None
     pv_series: Optional[pd.Series] = None
+    prosumer_medians: Optional[pd.DataFrame] = None
+    prosumer_series: Optional[pd.Series] = None
     hh_medians: Optional[pd.DataFrame] = None
     hh_series: Optional[pd.Series] = None
     shop_medians: Optional[pd.DataFrame] = None
@@ -22,6 +24,7 @@ class AppState:
     pun_h: Optional[pd.DataFrame] = None   # hourly PUN €/kWh (expanded)
 
     pv_file_digest: Optional[str] = None
+    prosumer_file_digest: Optional[str] = None
     hh_file_digest: Optional[str] = None
     shop_file_digest: Optional[str] = None
     zonal_file_digest: Optional[str] = None


### PR DESCRIPTION
## Summary
- add a dedicated prosumer median profile template and uploader alongside the HH/SHOP templates
- store and rebuild prosumer hourly profiles separately from household medians for surplus calculations
- use the prosumer-specific profile in deterministic simulations and enforce it as a required input

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921869a71a88332a94e6425b362a697)